### PR TITLE
Fix workflows on pull requests

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -17,9 +17,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -19,9 +19,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1


### PR DESCRIPTION
# Description

Fix github workflows on pull requests. In task logs:
```
Checking out the ref
  /usr/bin/git checkout --progress --force refs/remotes/pull/297/merge
  Note: switching to 'refs/remotes/pull/297/merge'.
```
so it is executed on the PR branch as it should be.

## How Has This Been Tested

A green mark on this PR proves it works.

- [x] Green mark on ESLint task
- [x] Green mark on Prettier task

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation/readme
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
