### PR TITLE
Added skip country CLI Option

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -6,11 +6,13 @@ const logger = require('./logger');
 const getAirportsByCountry = require('./getAirportsByCountry');
 const getAirport = require('./getAirport');
 const getCharts = require('./getCharts');
+const { count } = require('console');
 
 commander.program
   .option('--icao <ICAO_CODE>', 'Scrape only one specific airport by airport ICAO code')
   .option('--country <ISO_CODES>', 'Scrape all airports in specific countries by country ISO code')
   .option('--all', 'Scrape all airports in all the countries')
+  .option('--skip-country, --skipcountries [value...]', 'Skip these coutries by ISO code')
   .option('--prod', 'Run the command but dont publish to database')
   .parse(process.argv);
 
@@ -72,15 +74,23 @@ async function main() {
     logger.debug('Updated links', { type: 'general' });
   } else if (options.all) {
     logger.debug('Updating links', { type: 'general' });
-
+    let skip_list = [];
+    if(options.skipcountries)
+    {
+      skip_list = options.skipcountries;
+    }
     const playbooks = fs.readdirSync(playbooksDir);
 
     for (let i = 0; i < playbooks.length; i += 1) {
       const country = playbooks[i];
-      const fsPlaybook = fs.readFileSync(`${playbooksDir}/${country}`, 'utf8');
-      const playbook = JSON.parse(fsPlaybook);
-      const airports = getAirportsByCountry(playbook.country.iso);
-      await getCharts(playbook, airports, prodMode);
+      const isoCode = country.slice(0,-5); // Remove .json from FILE to get isoCode
+      if(!skip_list.includes(isoCode))
+      {
+        const fsPlaybook = fs.readFileSync(`${playbooksDir}/${country}`, 'utf8');
+        const playbook = JSON.parse(fsPlaybook);
+        const airports = getAirportsByCountry(playbook.country.iso);
+        await getCharts(playbook, airports, prodMode);
+      }
     }
 
     logger.debug('Updated links', { type: 'general' });

--- a/app/main.js
+++ b/app/main.js
@@ -6,13 +6,12 @@ const logger = require('./logger');
 const getAirportsByCountry = require('./getAirportsByCountry');
 const getAirport = require('./getAirport');
 const getCharts = require('./getCharts');
-const { count } = require('console');
 
 commander.program
   .option('--icao <ICAO_CODE>', 'Scrape only one specific airport by airport ICAO code')
   .option('--country <ISO_CODES>', 'Scrape all airports in specific countries by country ISO code')
   .option('--all', 'Scrape all airports in all the countries')
-  .option('--skip-country, --skipcountries [value...]', 'Skip these coutries by ISO code')
+  .option('--skip-country <ISO_CODES>', 'Skip scraping for all airports in specific countries by country ISO code')
   .option('--prod', 'Run the command but dont publish to database')
   .parse(process.argv);
 
@@ -74,18 +73,16 @@ async function main() {
     logger.debug('Updated links', { type: 'general' });
   } else if (options.all) {
     logger.debug('Updating links', { type: 'general' });
-    let skip_list = [];
-    if(options.skipcountries)
-    {
-      skip_list = options.skipcountries;
+    let skipList = [];
+    if (options.skipCountry) {
+      skipList = options.skipCountry.split(',');
     }
     const playbooks = fs.readdirSync(playbooksDir);
 
     for (let i = 0; i < playbooks.length; i += 1) {
       const country = playbooks[i];
-      const isoCode = country.slice(0,-5); // Remove .json from FILE to get isoCode
-      if(!skip_list.includes(isoCode))
-      {
+      const isoCode = country.slice(0, -5); // Remove .json from FILE to get isoCode
+      if (!skipList.includes(isoCode)) {
         const fsPlaybook = fs.readFileSync(`${playbooksDir}/${country}`, 'utf8');
         const playbook = JSON.parse(fsPlaybook);
         const airports = getAirportsByCountry(playbook.country.iso);


### PR DESCRIPTION
# Description

Added an option to skip country while scrapping all airports in all the countries.


Example: 
```bash
node app/main.js --all --skip-country IN US
```

this will scrap all except countries mentioned with ISO Code

Fixes #285 

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Test A
- [x] Test B

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation/readme
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
